### PR TITLE
fix for objects

### DIFF
--- a/object_test.js
+++ b/object_test.js
@@ -1,9 +1,9 @@
-suite('object', function () {
+suite('object', function() {
   var subject = require('./object');
   var assert = require('assert');
 
   function verify(title, input, output) {
-    test(title, function () {
+    test(title, function() {
       var result = subject.apply(subject, input);
       assert.deepEqual(output, result);
     });
@@ -11,15 +11,18 @@ suite('object', function () {
 
 
   verify(
-    'replace value in nested object', [{
-      foo: {
-        bar: '{{say.what}}'
+    'replace value in nested object',
+    [
+      {
+        foo: {
+          bar: '{{say.what}}'
+        }
+      },
+      {
+        say: { what: 'yeah' }
       }
-    }, {
-      say: {
-        what: 'yeah'
-      }
-    }], {
+    ],
+    {
       foo: {
         bar: 'yeah'
       }
@@ -27,32 +30,34 @@ suite('object', function () {
   );
 
   verify(
-    'replace keys', [{
-      'mykeywins{{yes}}': 'value'
-    }, {
-      yes: 'no'
-    }], {
-      'mykeywinsno': 'value'
-    }
+    'replace keys',
+    [
+      {
+        'mykeywins{{yes}}': 'value'
+      },
+      { yes: 'no' }
+    ],
+    { 'mykeywinsno': 'value' }
   );
 
   verify(
-    'boolean', [{
-      'woot': true
-    }, {}], {
-      woot: true
-    }
+    'boolean',
+    [{ 'woot': true }, {}],
+    { woot: true }
   );
 
   verify(
-    'undefined', [{
+    'undefined',
+    [
+      {
         key: 'value',
         object: {
           nested: undefined
         }
       },
       []
-    ], {
+    ],
+    {
       key: 'value',
       object: {
         nested: undefined
@@ -61,10 +66,12 @@ suite('object', function () {
   );
 
   verify(
-    'array', [
+    'array',
+    [
       ['foo', 'bar{{1}}', 'baz{{2}}'],
       ['ignore me', '-first', '-second']
-    ], [
+    ],
+    [
       'foo',
       'bar-first',
       'baz-second'
@@ -72,32 +79,20 @@ suite('object', function () {
   );
 
   verify(
-    'number', [{
-      xfoo: 1
-    }, {}], {
-      xfoo: 1
-    }
+    'number',
+    [{ xfoo: 1 }, {}],
+    { xfoo: 1 }
   );
 
   verify(
-    'nested arrays', [
-      '{{some.arrays}}'
-    , {
-      some: {
-        arrays: [1, [2, [{3: 4}]]]
-      }
-    }],
-      [1, [2, [{3: 4}]]]
+    'nested arrays', ['{{some.arrays}}',
+    { some: { arrays: [1, [2, [{3: 4}]]] } }],
+    [1, [2, [{3: 4}]]]
   );
 
   verify(
-    'nested objects', [
-      '{{some.object}}'
-    , {
-      some: {
-        object: {3: {4: 5}}
-      }
-    }],
+    'nested objects', ['{{some.object}}',
+    { some: { object: {3: {4: 5}} } }],
     {3: {4: 5}}
   );
 

--- a/object_test.js
+++ b/object_test.js
@@ -85,29 +85,37 @@ suite('object', function() {
   );
 
   verify(
-    'nested arrays', ['{{some.arrays}}',
-    { some: { arrays: [1, [2, [{3: 4}]]] } }],
+    'nested arrays',
+    [
+      '{{some.arrays}}',
+      { some: { arrays: [1, [2, [{3: 4}]]] } }
+    ],
     [1, [2, [{3: 4}]]]
   );
 
   verify(
-    'nested objects', ['{{some.object}}',
-    { some: { object: {3: {4: 5}} } }],
+    'nested objects', [
+      '{{some.object}}',
+      { some: { object: {3: {4: 5}} } }
+    ],
     {3: {4: 5}}
   );
 
   verify(
-    'nested arrays in objects and objects in arrays', [{
-      'arrays{{some.arrays.0}}': '{{some.arrays}}',
-      'object{{some.arrays.1.0}}': '{{some.object}}'
-    }, {
-      some: {
-        arrays: [1, [2, [{3: 4}]]],
-        object: {3: {4: 5}}
+    'nested arrays in objects and objects in arrays',
+    [
+      {
+        'arrays{{some.arrays.0}}': '{{some.arrays}}',
+        'object{{some.arrays.1.0}}': '{{some.object}}'
+      }, {
+        some: {
+          arrays: [1, [2, [{ 3: 4 }]]],
+          object: { 3: { 4: 5 }}
+        }
       }
-    }], {
-      arrays1: [1, [2, [{3: 4}]]],
-      object2: {3: {4: 5}}
+    ], {
+      arrays1: [1, [2, [{ 3: 4 }]]],
+      object2: { 3: { 4: 5 }}
     }
   );
 

--- a/object_test.js
+++ b/object_test.js
@@ -1,9 +1,9 @@
-suite('object', function() {
+suite('object', function () {
   var subject = require('./object');
   var assert = require('assert');
 
   function verify(title, input, output) {
-    test(title, function() {
+    test(title, function () {
       var result = subject.apply(subject, input);
       assert.deepEqual(output, result);
     });
@@ -11,18 +11,15 @@ suite('object', function() {
 
 
   verify(
-    'replace value in nested object',
-    [
-      {
-        foo: {
-          bar: '{{say.what}}'
-        }
-      },
-      {
-        say: { what: 'yeah' }
+    'replace value in nested object', [{
+      foo: {
+        bar: '{{say.what}}'
       }
-    ],
-    {
+    }, {
+      say: {
+        what: 'yeah'
+      }
+    }], {
       foo: {
         bar: 'yeah'
       }
@@ -30,34 +27,32 @@ suite('object', function() {
   );
 
   verify(
-    'replace keys',
-    [
-      {
-        'mykeywins{{yes}}': 'value'
-      },
-      { yes: 'no' }
-    ],
-    { 'mykeywinsno': 'value' }
+    'replace keys', [{
+      'mykeywins{{yes}}': 'value'
+    }, {
+      yes: 'no'
+    }], {
+      'mykeywinsno': 'value'
+    }
   );
 
   verify(
-    'boolean',
-    [{ 'woot': true }, {}],
-    { woot: true }
+    'boolean', [{
+      'woot': true
+    }, {}], {
+      woot: true
+    }
   );
 
   verify(
-    'undefined',
-    [
-      {
+    'undefined', [{
         key: 'value',
         object: {
           nested: undefined
         }
       },
       []
-    ],
-    {
+    ], {
       key: 'value',
       object: {
         nested: undefined
@@ -66,12 +61,10 @@ suite('object', function() {
   );
 
   verify(
-    'array',
-    [
+    'array', [
       ['foo', 'bar{{1}}', 'baz{{2}}'],
       ['ignore me', '-first', '-second']
-    ],
-    [
+    ], [
       'foo',
       'bar-first',
       'baz-second'
@@ -79,8 +72,34 @@ suite('object', function() {
   );
 
   verify(
-    'number',
-    [{ xfoo: 1 }, {}],
-    { xfoo: 1 }
+    'number', [{
+      xfoo: 1
+    }, {}], {
+      xfoo: 1
+    }
   );
+
+  verify(
+    'nested arrays', [
+      '{{some.arrays}}'
+    , {
+      some: {
+        arrays: [1, [2, [{3: 4}]]]
+      }
+    }],
+      [1, [2, [{3: 4}]]]
+  );
+
+  verify(
+    'nested arrays in objects', [{
+      arrays: '{{some.arrays}}'
+    }, {
+      some: {
+        arrays: [1, [2, [{3: 4}]]]
+      }
+    }], {
+      arrays: [1, [2, [{3: 4}]]]
+    }
+  );
+
 });

--- a/object_test.js
+++ b/object_test.js
@@ -91,14 +91,28 @@ suite('object', function () {
   );
 
   verify(
-    'nested arrays in objects', [{
-      arrays: '{{some.arrays}}'
+    'nested objects', [
+      '{{some.object}}'
+    , {
+      some: {
+        object: {3: {4: 5}}
+      }
+    }],
+    {3: {4: 5}}
+  );
+
+  verify(
+    'nested arrays in objects and objects in arrays', [{
+      'arrays{{some.arrays.0}}': '{{some.arrays}}',
+      'object{{some.arrays.1.0}}': '{{some.object}}'
     }, {
       some: {
-        arrays: [1, [2, [{3: 4}]]]
+        arrays: [1, [2, [{3: 4}]]],
+        object: {3: {4: 5}}
       }
     }], {
-      arrays: [1, [2, [{3: 4}]]]
+      arrays1: [1, [2, [{3: 4}]]],
+      object2: {3: {4: 5}}
     }
   );
 

--- a/string.js
+++ b/string.js
@@ -52,13 +52,20 @@ NOTE: I also wrote an implementation that does not use regex but it is actually 
 function replace(input, view) {
   // optimization to avoid regex calls (indexOf is strictly faster)
   if (input.indexOf(TEMPLATE_OPEN) === -1) return input;
-  return input.replace(REGEX, function(whole, path) {
+  var result;
+  var replaced = input.replace(REGEX, function(whole, path) {
     var value = extractValue(path, view);
     if (value) {
-      return value;
+      if (Array.isArray(value)) {
+        result = value;
+        return;
+      } else {
+        return value;
+      }
     }
     return whole;
   });
+  return result ? result : replaced;
 }
 
 module.exports = replace;

--- a/string.js
+++ b/string.js
@@ -56,7 +56,7 @@ function replace(input, view) {
   var replaced = input.replace(REGEX, function(whole, path) {
     var value = extractValue(path, view);
     if (value) {
-      if (Array.isArray(value)) {
+      if (typeof value === 'object') {
         result = value;
         return;
       } else {


### PR DESCRIPTION
String.prototype.replace returns a new string, so returning a value like `[1, [2, [ {3: 4} ] ] ]` from the replacement function will return something delightfully irritating like `"1,2,[object Object]"` from replace()

In this I've simply sent object values back explicitly and left all others as is

Tests included
