### PR TITLE
feat(object): reference to key in handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,76 @@ object(
 
 ```
 
+### Custom render
+
+You can override default renderer using the third argument in `object` (`json-templater/string` is default):
+
+`template.json:`
+```json
+{
+  "magic": {
+    "key": "interpolation is nice {{value}}"
+  }
+}
+```
+
+```js
+var object = require('json-templater/object');
+
+object(
+  require('./template.json'),
+  { magic: 'key', value: 'value' },
+  function (value, data, key) {
+    return value;
+  }
+);
+
+// result
+
+{
+  "magic": {
+    "key": "interpolation is nice {{value}}"
+  }
+}
+```
+
+#### key reference
+
+Handler function gets three arguments:
+
+- `value`: value which is about to be handled
+- `data`: initial template data object
+- `key`: key corresponding to the value
+
+Using this data some complex logic could be implemented, for instance:
+
+```js
+var object = require('json-templater/object');
+var string = require('json-templater/string');
+
+object(
+  require('./template.json'),
+  { magic: 'key', value: 'value' },
+  function (value, data, key) {
+    // custom renderer for some special value
+    if (key === 'specialKey') {
+      return 'foo';
+    }
+    // usual string renderer
+    return string(value, data);
+  }
+);
+
+// result
+
+{
+  magic: {
+    specialKey: "foo",
+    key: "interpolation is nice value"
+  }
+}
+```
+
 ## LICENSE
 
 Copyright (c) 2014 Mozilla Foundation

--- a/object.js
+++ b/object.js
@@ -5,7 +5,7 @@ function walkObject(object, handler) {
   var result = {};
 
   for (var key in object) {
-    result[walk(key, handler)] = walk(object[key], handler);
+    result[walk(key, handler, null)] = walk(object[key], handler, key);
   }
 
   return result;
@@ -13,7 +13,7 @@ function walkObject(object, handler) {
 
 function walkArray(array, handler) {
   return array.map(function(input) {
-    return walk(input, handler);
+    return walk(input, handler, null);
   });
 }
 
@@ -25,8 +25,9 @@ template functions on keys _and_ values which most clone things don't do.
 
 @param {Object} input object to walk and duplicate.
 @param {Function} handler handler to invoke on string types.
+@param {?String} [key] key corresponding to input, if the latter is a value in object
 */
-function walk(input, handler) {
+function walk(input, handler, key) {
   switch (typeof input) {
     // object is slightly special if null we move on
     case 'object':
@@ -34,7 +35,7 @@ function walk(input, handler) {
       return walkObject(input, handler);
 
     case 'string':
-      return handler(input);
+      return handler(input, key);
     // all other types cannot be mutated
     default:
       return input;
@@ -44,9 +45,9 @@ function walk(input, handler) {
 function render(object, view, handler) {
   handler = handler || renderString;
 
-  return walk(object, function(value) {
-    return handler(value, view);
-  });
+  return walk(object, function(value, key) {
+    return handler(value, view, key);
+  }, null);
 }
 
 module.exports = render;

--- a/object_test.js
+++ b/object_test.js
@@ -1,8 +1,9 @@
 suite('object', function() {
   var subject = require('./object');
+  var renderString = require('./string');
   var assert = require('assert');
 
-  function verify(title, input, output) {
+  function verify(title, input, output, handler) {
     test(title, function() {
       var result = subject.apply(subject, input);
       assert.deepEqual(output, result);
@@ -116,6 +117,31 @@ suite('object', function() {
     ], {
       arrays1: [1, [2, [{ 3: 4 }]]],
       object2: { 3: { 4: 5 }}
+    }
+  );
+
+  verify(
+    'custom handler',
+    [
+      {
+        foo: 'hello from {{foo}}',
+        bar: 'hello from {{bar}}'
+      },
+      {
+        foo: 'foo',
+        bar: 'bar'
+      },
+      function(value, view, key) {
+        // let's render the corresponding value in a different way
+        if (key === 'foo') {
+          return value;
+        }
+        return renderString(value, view);
+      }
+    ],
+    {
+      foo: 'hello from {{foo}}',
+      bar: 'hello from bar'
     }
   );
 


### PR DESCRIPTION
Hi James,

first of all, thanks for your work! We've been using this package for a while and it works perfectly.

I'd like to introduce a new feature: reference to a key in handler function, it allows to implement some complex logic of rendering.

For instance, it allows to implement the following:

```js
const ejs = require('ejs');
const jsonTemplater = require('json-templater');

jsonTemplater.object(
    {
        ejs: '<% if (foo) { %>I`ve been rendered with ejs!<% } %>',
        usualKey: 'some usual value (will be rendered as usual)'
    },
    { foo: true },
    function (value, data, key) {
        // I can handle value corresponds to 'ejs' key using different template engine
        if (key === 'ejs') {
            return ejs.render(value, data);
        }
        return jsonTemplater.string(value, data);
    }
);
```

**This change does NOT break backward compatibility**

Also, I added some documentation:

- the section about a custom handler: now it's a hidden feature that could be found out only reading code :)
- the new section about this new ability to using not only values but corresponding keys

Looking forward your answer!